### PR TITLE
Bech32m with Taproot

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <td class="signing">ECDSA</td>
             <td class="curve">secp256k1</td>
             <td class="hash">SHA-256</td>
-            <td class="addr">base58, bech32</td>
+            <td class="addr">base58, Bech32m</td>
             <td class="addr">SHA-256, RIPEMD-160</td>
         </tr>
         <!-- ETHEREUM-->


### PR DESCRIPTION
Bitcoin now uses Bech32m with Taproot. Reference: https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki